### PR TITLE
add didUpdateWidget lifecycle to handle changes to pickerColor

### DIFF
--- a/lib/flutter_colorpicker.dart
+++ b/lib/flutter_colorpicker.dart
@@ -156,6 +156,18 @@ class _ColorPickerState extends State<ColorPicker> {
   }
 
   @override
+  void didUpdateWidget(ColorPicker oldWidget) {
+    chessTexture = base64.decode(base64EncodedImage);
+    HSVColor color = HSVColor.fromColor(widget.pickerColor);
+    hue = color.hue;
+    saturation = color.saturation;
+    value = color.value;
+    alpha = color.alpha;
+    setState(() => getColorValue());
+    super.didUpdateWidget(oldWidget);
+  }
+
+  @override
   Widget build(BuildContext context) {
     Orientation _orientation = MediaQuery.of(context).orientation;
 


### PR DESCRIPTION
## Changes
Add `didUpdateWidget` lifecycle hook to handle updates to `pickerColor`.

## Issues this PR resolves
Currently the `ColorPicker` widget does not update when a new value is passed into `pickerColor`.

Example: This example places a TextField above the `ColorPicker` widget, and updates the `pickerColor` when the Textfield is set to a new hex color.
```
class HexColor extends Color {
  static int _getColorFromHex(String hexColor) {
    hexColor = hexColor.toUpperCase().replaceAll("#", "");
    if (hexColor.length == 6) {
      hexColor = "FF" + hexColor;
    }
    return int.parse(hexColor, radix: 16);
  }
  HexColor(final String hexColor) : super(_getColorFromHex(hexColor));
}

class ColorDialog extends StatefulWidget {
  ColorDialog({this.color});
  Color color;
  @override
  ColorDialogState createState() => new ColorDialogState();
}

class ColorDialogState extends State<ColorDialog> {
  Color _color;
  @override
  void initState() {
    _color = widget.color;
    super.initState();
  }

  @override
  Widget build(BuildContext context) {
    return AlertDialog(
      title: const Text('Theme Color'),
      content: Container(
        width: double.maxFinite,
        child: ListView(
          shrinkWrap: true,
          children: [
            TextField(
              onChanged: (String val) {
                if (val.length == 6) {
                  setState(() {
                    _color = HexColor(val);
                  });
                }
              },
            ),
            ColorPicker(
              pickerColor: _color,
              onColorChanged: (Color newColor) {
                _color = newColor;
              },
              enableLabel: true,
              enableAlpha: false,
              pickerAreaHeightPercent: 0.5,
            ),
          ],
        ),
      ),
      actions: <Widget>[
        FlatButton(
          child: Text('Cancel'),
          onPressed: () {
            Navigator.of(context).pop();
          },
        ),
        FlatButton(
          child: Text('Save'),
          onPressed: () {
            Navigator.of(context).pop(_color);
          },
        ),
      ],
    );
  }
}
```