### PR TITLE
Fixed the slider

### DIFF
--- a/lib/flutter_colorpicker.dart
+++ b/lib/flutter_colorpicker.dart
@@ -1,5 +1,6 @@
 export 'package:flutter_colorpicker/src/colorpicker.dart';
 export 'package:flutter_colorpicker/src/hsv_picker.dart';
+export 'package:flutter_colorpicker/src/hsv_colorpicker.dart';
 export 'package:flutter_colorpicker/src/material_picker.dart';
 export 'package:flutter_colorpicker/src/block_picker.dart';
 export 'package:flutter_colorpicker/src/utils.dart';

--- a/lib/src/colorpicker.dart
+++ b/lib/src/colorpicker.dart
@@ -302,7 +302,7 @@ class _SlidePickerState extends State<SlidePicker> {
                   child: Text(
                     palette.toString().split('.').last[0].toUpperCase(),
                     style: widget.sliderTextStyle ??
-                        Theme.of(context).textTheme.body2.copyWith(
+                        Theme.of(context).textTheme.bodyText1.copyWith(
                             fontWeight: FontWeight.bold, fontSize: 16.0),
                   ),
                 ),

--- a/lib/src/hsv_colorpicker.dart
+++ b/lib/src/hsv_colorpicker.dart
@@ -1,0 +1,176 @@
+/// HSV(HSB)/HSL Color Picker example
+///
+/// You can create your own layout by importing `hsv_picker.dart`.
+
+library hsv_colorpicker;
+
+import 'package:flutter/material.dart';
+
+import 'package:flutter_colorpicker/src/hsv_picker.dart';
+
+class HsvColorPicker extends StatefulWidget {
+  const HsvColorPicker({
+    @required this.pickerColor,
+    @required this.onColorChanged,
+    this.paletteType: PaletteType.hsv,
+    this.enableAlpha: true,
+    this.showLabel: true,
+    this.labelTextStyle,
+    this.displayThumbColor: false,
+    this.colorPickerWidth: 300.0,
+    this.pickerAreaHeightPercent: 1.0,
+    this.pickerAreaBorderRadius: const BorderRadius.all(Radius.zero),
+  })  : assert(paletteType != null),
+        assert(enableAlpha != null),
+        assert(showLabel != null),
+        assert(pickerAreaBorderRadius != null);
+
+  final HSVColor pickerColor;
+  final ValueChanged<HSVColor> onColorChanged;
+  final PaletteType paletteType;
+  final bool enableAlpha;
+  final bool showLabel;
+  final TextStyle labelTextStyle;
+  final bool displayThumbColor;
+  final double colorPickerWidth;
+  final double pickerAreaHeightPercent;
+  final BorderRadius pickerAreaBorderRadius;
+
+  @override
+  _HsvColorPickerState createState() => _HsvColorPickerState();
+}
+
+class _HsvColorPickerState extends State<HsvColorPicker> {
+  HSVColor currentHsvColor = const HSVColor.fromAHSV(0.0, 0.0, 0.0, 0.0);
+
+  @override
+  void initState() {
+    super.initState();
+    currentHsvColor = widget.pickerColor;
+  }
+
+  @override
+  void didUpdateWidget(HsvColorPicker oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    currentHsvColor = widget.pickerColor;
+  }
+
+  Widget colorPickerSlider(TrackType trackType) {
+    return ColorPickerSlider(
+      trackType,
+      currentHsvColor,
+      (HSVColor color) {
+        setState(() => currentHsvColor = color);
+        widget.onColorChanged(currentHsvColor);
+      },
+      displayThumbColor: widget.displayThumbColor,
+    );
+  }
+
+  Widget colorPickerArea() {
+    return ClipRRect(
+      borderRadius: widget.pickerAreaBorderRadius,
+      child: ColorPickerArea(
+        currentHsvColor,
+        (HSVColor color) {
+          setState(() => currentHsvColor = color);
+          widget.onColorChanged(currentHsvColor);
+        },
+        widget.paletteType,
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (MediaQuery.of(context).orientation == Orientation.portrait) {
+      return Column(
+        children: <Widget>[
+          SizedBox(
+            width: widget.colorPickerWidth,
+            height: widget.colorPickerWidth * widget.pickerAreaHeightPercent,
+            child: colorPickerArea(),
+          ),
+          Padding(
+            padding: const EdgeInsets.fromLTRB(15.0, 5.0, 10.0, 5.0),
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: <Widget>[
+                ColorIndicator(currentHsvColor),
+                Expanded(
+                  child: Column(
+                    children: <Widget>[
+                      SizedBox(
+                        height: 40.0,
+                        width: widget.colorPickerWidth - 75.0,
+                        child: colorPickerSlider(TrackType.hue),
+                      ),
+                      if (widget.enableAlpha)
+                        SizedBox(
+                          height: 40.0,
+                          width: widget.colorPickerWidth - 75.0,
+                          child: colorPickerSlider(TrackType.alpha),
+                        ),
+                    ],
+                  ),
+                ),
+              ],
+            ),
+          ),
+          if (widget.showLabel)
+            ColorPickerLabel(
+              currentHsvColor,
+              enableAlpha: widget.enableAlpha,
+              textStyle: widget.labelTextStyle,
+            ),
+          SizedBox(height: 20.0),
+        ],
+      );
+    } else {
+      return Row(
+        children: <Widget>[
+          Expanded(
+            child: SizedBox(
+              width: 300.0,
+              height: 200.0,
+              child: colorPickerArea(),
+            ),
+          ),
+          Column(
+            children: <Widget>[
+              Row(
+                children: <Widget>[
+                  SizedBox(width: 20.0),
+                  ColorIndicator(currentHsvColor),
+                  Column(
+                    children: <Widget>[
+                      SizedBox(
+                        height: 40.0,
+                        width: 260.0,
+                        child: colorPickerSlider(TrackType.hue),
+                      ),
+                      if (widget.enableAlpha)
+                        SizedBox(
+                          height: 40.0,
+                          width: 260.0,
+                          child: colorPickerSlider(TrackType.alpha),
+                        ),
+                    ],
+                  ),
+                  SizedBox(width: 10.0),
+                ],
+              ),
+              SizedBox(height: 20.0),
+              if (widget.showLabel)
+                ColorPickerLabel(
+                  currentHsvColor,
+                  enableAlpha: widget.enableAlpha,
+                  textStyle: widget.labelTextStyle,
+                ),
+            ],
+          ),
+        ],
+      );
+    }
+  }
+}

--- a/lib/src/hsv_picker.dart
+++ b/lib/src/hsv_picker.dart
@@ -475,7 +475,9 @@ class ColorPickerSlider extends StatelessWidget {
         localDx.clamp(0.0, box.maxWidth - 30.0) / (box.maxWidth - 30.0);
     switch (trackType) {
       case TrackType.hue:
-        onColorChanged(hsvColor.withHue(progress * 360));
+        // 360 is the same as zero
+        // if set to 360, sliding to end goes to zero
+        onColorChanged(hsvColor.withHue(progress * 359));
         break;
       case TrackType.saturation:
         onColorChanged(hsvColor.withSaturation(progress));

--- a/lib/src/hsv_picker.dart
+++ b/lib/src/hsv_picker.dart
@@ -416,7 +416,7 @@ class _ColorPickerLabelState extends State<ColorPickerLabel> {
                   Text(
                     item,
                     style: widget.textStyle ??
-                        Theme.of(context).textTheme.body1.copyWith(
+                        Theme.of(context).textTheme.bodyText2.copyWith(
                             fontWeight: FontWeight.bold, fontSize: 16.0),
                   ),
                   SizedBox(height: 10.0),


### PR DESCRIPTION
There were two problems with the slider on the color picker.  One was the hue slider went to 360 which is the same as 0, so sliding to the end would pop the slider to zero.

The other issue was due to the conversion from HSVColor to Color.  When this happens, hue information is lost and the slider appears stuck.  For example you could have white, add some hue, but the conversion to Color gets you pure white and then the slider pops back to zero and is not movable. The solution is to use the new HsvColorPicker and pass HSVColors instead of colors.  Then you don't lose info as the widget reloads on color change.