### PR TITLE
Update slider picker indicator clip behavior

### DIFF
--- a/lib/src/colorpicker.dart
+++ b/lib/src/colorpicker.dart
@@ -249,6 +249,7 @@ class _SlidePickerState extends State<SlidePicker> {
   Widget indicator() {
     return ClipRRect(
       borderRadius: widget.indicatorBorderRadius,
+      clipBehavior: Clip.antiAliasWithSaveLayer,
       child: Container(
         width: widget.indicatorSize.width,
         height: widget.indicatorSize.height,


### PR DESCRIPTION
Hi @mchome,
thanks for the great package!

I was using the `SlidePicker` with an `indicatorBorderRadius` and noticed that the indicator has anti aliasing artifacts (as shown in the image below).
I believe this is due to the default `clipBehavior` of the `ClipRRect` changing from `Clip.antiAliasWithSaveLayer` to `Clip.antiAlias` in Flutter 1.20.0 (released early August) as described [here](https://flutter.dev/go/clip-behavior).

In this PR I just changed the `clipBehavior` to `Clip.antiAliasWithSaveLayer` for the `SlidePicker` indicator.

| with default clipBehavior (current) | with Clip.antiAliasWithSaveLaye (this PR) |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/20045287/91346208-c7437980-e7e0-11ea-9ddc-82abcb07748e.png) | ![image](https://user-images.githubusercontent.com/20045287/91346197-c3175c00-e7e0-11ea-92dd-53529927a01c.png) |
