### PR TITLE
Update colorpicker.dart

### DIFF
--- a/lib/src/colorpicker.dart
+++ b/lib/src/colorpicker.dart
@@ -120,10 +120,12 @@ class _ColorPickerState extends State<ColorPicker> {
             ),
           ),
           if (widget.showLabel)
+          FittedBox(child:
             ColorPickerLabel(
               currentHsvColor,
               enableAlpha: widget.enableAlpha,
               textStyle: widget.labelTextStyle,
+             ),
             ),
           SizedBox(height: 20.0),
         ],


### PR DESCRIPTION
Fixed RenderFlex overflowed on the right . It occurs on small screens while Alpha=100% at HSV. 