### PR TITLE
Updating addAllowedPointer

### DIFF
--- a/lib/src/hsv_picker.dart
+++ b/lib/src/hsv_picker.dart
@@ -727,7 +727,7 @@ class ColorPickerArea extends StatelessWidget {
 
 class AlwaysWinPanGestureRecognizer extends PanGestureRecognizer {
   @override
-  void addAllowedPointer(PointerEvent event) {
+  void addAllowedPointer(PointerDownEvent event) {
     super.addAllowedPointer(event);
     resolve(GestureDisposition.accepted);
   }


### PR DESCRIPTION
Hey @mchome, thanks for your package again.

I'm pulling this request because addAllowedPointer [requires PointerDownEvent](https://github.com/flutter/flutter/pull/82834) on Flutter's master channel now. Not necessary to accept this ASAP, since it's just merged literally a few days ago. But you can keep your eye on it before it landed on more mature branches.