### PR TITLE
Manual Hex Input (via TextEditingController)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [0.6.0]
 
 - Added ***hexInputController*** for Manual Hex Input [#31](https://github.com/mchome/flutter_colorpicker/issues/31).
-- Added 122 tests and documentation for colorToHex and colorFromHex.
+- Added 122 tests and documentation for colorToHex() and colorFromHex().
 - Update example app.
 
 ## [0.5.0]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## [0.6.0]
+
+- Added ***hexInputController*** for Manual Hex Input [#31](https://github.com/mchome/flutter_colorpicker/issues/31).
+- Added 122 tests and documentation for colorToHex and colorFromHex.
+- Update example app.
+
 ## [0.5.0]
 
 - [#45](https://github.com/mchome/flutter_colorpicker/pull/36) GestureRecognizer Cleanup.

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,4 +1,6 @@
+import 'package:flutter/cupertino.dart' show CupertinoTextField;
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 // import 'package:flutter/foundation.dart'
 //     show debugDefaultTargetPlatformOverride;
 
@@ -21,6 +23,18 @@ class _MyAppState extends State<MyApp> {
 
   void changeColor(Color color) => setState(() => currentColor = color);
   void changeColors(List<Color> colors) => setState(() => currentColors = colors);
+
+  // Just an example of how to use/interpret/format text input's result.
+  Future<void> copyToClipboard(String input) async {
+    late String textToCopy;
+    final hex = input.toUpperCase();
+    if (hex.startsWith('FF') && hex.length == 8) {
+      textToCopy = hex.replaceFirst('FF', '');
+    } else {
+      textToCopy = hex;
+    }
+    await Clipboard.setData(ClipboardData(text: '#$textToCopy'));
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -105,7 +119,7 @@ class _MyAppState extends State<MyApp> {
                                 showLabel: false,
                                 showIndicator: true,
                                 indicatorBorderRadius:
-                                const BorderRadius.vertical(
+                                    const BorderRadius.vertical(
                                   top: const Radius.circular(25.0),
                                 ),
                               ),
@@ -115,6 +129,88 @@ class _MyAppState extends State<MyApp> {
                       );
                     },
                     child: const Text('Change me again'),
+                    color: currentColor,
+                    textColor: useWhiteForeground(currentColor)
+                        ? const Color(0xffffffff)
+                        : const Color(0xff000000),
+                  ),
+                  MaterialButton(
+                    elevation: 3.0,
+                    onPressed: () {
+                      // The initial value can be provided directly to the controller.
+                      final textController =
+                          TextEditingController(text: '#2F19DB');
+                      showDialog(
+                        context: context,
+                        builder: (BuildContext context) {
+                          return AlertDialog(
+                            scrollable: true,
+                            titlePadding: const EdgeInsets.all(0.0),
+                            contentPadding: const EdgeInsets.all(0.0),
+                            content: Column(
+                              children: [
+                                ColorPicker(
+                                  pickerColor: currentColor,
+                                  onColorChanged: changeColor,
+                                  colorPickerWidth: 300.0,
+                                  pickerAreaHeightPercent: 0.7,
+                                  enableAlpha:
+                                      true, // hexInputController will respect it too.
+                                  displayThumbColor: true,
+                                  showLabel: true,
+                                  paletteType: PaletteType.hsv,
+                                  pickerAreaBorderRadius: const BorderRadius.only(
+                                    topLeft: const Radius.circular(2.0),
+                                    topRight: const Radius.circular(2.0),
+                                  ),
+                                  hexInputController: textController, // <- here
+                                  portraitOnly: true,
+                                ),
+                                Padding(
+                                  padding: const EdgeInsets.all(16),
+                                  /* It can be any text field, for example:
+
+                                  * TextField
+                                  * TextFormField
+                                  * CupertinoTextField
+                                  * EditableText
+                                  * any text field from 3-rd party package
+                                  * your own text field
+
+                                  so basically anything that supports/uses
+                                  a TextEditingController for an editable text.
+                                  */
+                                  child: CupertinoTextField(
+                                    controller: textController,
+                                    // Everything below is purely optional.
+                                    prefix: Padding(
+                                      padding: const EdgeInsets.only(left: 8),
+                                      child: const Icon(Icons.tag),
+                                    ),
+                                    suffix: IconButton(
+                                      icon:
+                                          const Icon(Icons.content_paste_rounded),
+                                      onPressed: () async =>
+                                          copyToClipboard(textController.text),
+                                    ),
+                                    autofocus: true,
+                                    maxLength: 9,
+                                    inputFormatters: [
+                                      // Any custom input formatter can be passed
+                                      // here or use any Form validator you want.
+                                      UpperCaseTextFormatter(),
+                                      FilteringTextInputFormatter.allow(
+                                          RegExp(kValidHexPattern)),
+                                    ],
+                                  ),
+                                )
+                              ],
+                            ),
+                          );
+                        },
+                      );
+                    },
+                    child: const Text('Change me via text input'),
                     color: currentColor,
                     textColor: useWhiteForeground(currentColor)
                         ? const Color(0xffffffff)
@@ -202,8 +298,7 @@ class _MyAppState extends State<MyApp> {
                             ? const Color(0xffffffff)
                             : const Color(0xff000000),
                       )
-                    ]
-                ),
+                    ]),
               ),
             ],
           ),
@@ -211,4 +306,10 @@ class _MyAppState extends State<MyApp> {
       ),
     );
   }
+}
+
+class UpperCaseTextFormatter extends TextInputFormatter {
+  @override
+  TextEditingValue formatEditUpdate(_, TextEditingValue nv) =>
+      TextEditingValue(text: nv.text.toUpperCase(), selection: nv.selection);
 }

--- a/lib/src/colorpicker.dart
+++ b/lib/src/colorpicker.dart
@@ -7,6 +7,7 @@ library hsv_picker;
 import 'package:flutter/material.dart';
 
 import 'package:flutter_colorpicker/src/hsv_picker.dart';
+import 'package:flutter_colorpicker/src/utils.dart';
 
 // The default layout of Color Picker.
 class ColorPicker extends StatefulWidget {
@@ -22,6 +23,7 @@ class ColorPicker extends StatefulWidget {
     this.colorPickerWidth: 300.0,
     this.pickerAreaHeightPercent: 1.0,
     this.pickerAreaBorderRadius: const BorderRadius.all(Radius.zero),
+    this.hexInputController,
   });
 
   final Color pickerColor;
@@ -36,6 +38,109 @@ class ColorPicker extends StatefulWidget {
   final double pickerAreaHeightPercent;
   final BorderRadius pickerAreaBorderRadius;
 
+  /// Allows setting the color using text input, via [TextEditingController].
+  ///
+  /// Listens to [String] input and trying to convert it to the valid [Color].
+  /// Contains basic validator, that requires final input to be provided
+  /// in one of those formats:
+  ///
+  /// * RRGGBB
+  /// * #RRGGBB
+  /// * AARRGGBB
+  /// * #AARRGGBB
+  ///
+  /// Where: AA stands for Alpha, RR for Red, GG for Green, and BB for blue color.
+  /// It will only accept 6/8 long HEXs with an optional hash (`#`) at the beginning.
+  /// Allowed characters are Latin A-F case insensitive and numbers 0-9.
+  /// It does respect the [enableAlpha] flag, so if alpha is disabled, all inputs
+  /// with transparency are also converted to non-transparent color values.
+  /// ```dart
+  ///   MaterialButton(
+  ///    elevation: 3.0,
+  ///    onPressed: () {
+  ///      // The initial value can be provided directly to the controller.
+  ///      final textController =
+  ///          TextEditingController(text: '#2F19DB');
+  ///      showDialog(
+  ///        context: context,
+  ///        builder: (BuildContext context) {
+  ///          return AlertDialog(
+  ///            scrollable: true,
+  ///            titlePadding: const EdgeInsets.all(0.0),
+  ///            contentPadding: const EdgeInsets.all(0.0),
+  ///            content: Column(
+  ///              children: [
+  ///                ColorPicker(
+  ///                  pickerColor: currentColor,
+  ///                  onColorChanged: changeColor,
+  ///                  colorPickerWidth: 300.0,
+  ///                  pickerAreaHeightPercent: 0.7,
+  ///                  enableAlpha:
+  ///                      true, // hexInputController will respect it too.
+  ///                  displayThumbColor: true,
+  ///                  showLabel: true,
+  ///                  paletteType: PaletteType.hsv,
+  ///                  pickerAreaBorderRadius: const BorderRadius.only(
+  ///                    topLeft: const Radius.circular(2.0),
+  ///                    topRight: const Radius.circular(2.0),
+  ///                  ),
+  ///                  hexInputController: textController, // <- here
+  ///                  portraitOnly: true,
+  ///                ),
+  ///                Padding(
+  ///                  padding: const EdgeInsets.all(16),
+  ///                  /* It can be any text field, for example:
+  ///                  * TextField
+  ///                  * TextFormField
+  ///                  * CupertinoTextField
+  ///                  * EditableText
+  ///                  * any text field from 3-rd party package
+  ///                  * your own text field
+  ///                  so basically anything that supports/uses
+  ///                  a TextEditingController for an editable text.
+  ///                  */
+  ///                  child: CupertinoTextField(
+  ///                    controller: textController,
+  ///                    // Everything below is purely optional.
+  ///                    prefix: Padding(
+  ///                      padding: const EdgeInsets.only(left: 8),
+  ///                      child: const Icon(Icons.tag),
+  ///                    ),
+  ///                    suffix: IconButton(
+  ///                      icon:
+  ///                          const Icon(Icons.content_paste_rounded),
+  ///                      onPressed: () async =>
+  ///                          copyToClipboard(textController.text),
+  ///                    ),
+  ///                    autofocus: true,
+  ///                    maxLength: 9,
+  ///                    inputFormatters: [
+  ///                      // Any custom input formatter can be passed
+  ///                      // here or use any Form validator you want.
+  ///                      UpperCaseTextFormatter(),
+  ///                      FilteringTextInputFormatter.allow(
+  ///                          RegExp(kValidHexPattern)),
+  ///                    ],
+  ///                  ),
+  ///                )
+  ///              ],
+  ///            ),
+  ///          );
+  ///        },
+  ///      );
+  ///    },
+  ///    child: const Text('Change me via text input'),
+  ///    color: currentColor,
+  ///    textColor: useWhiteForeground(currentColor)
+  ///        ? const Color(0xffffffff)
+  ///        : const Color(0xff000000),
+  ///  ),
+  /// ```
+  ///
+  /// Do not forget to `dispose()` your [TextEditingController] if you creating
+  /// it inside any kind of [StatefulWidget]'s [State].
+  final TextEditingController? hexInputController;
+
   @override
   _ColorPickerState createState() => _ColorPickerState();
 }
@@ -47,6 +152,16 @@ class _ColorPickerState extends State<ColorPicker> {
   void initState() {
     super.initState();
     currentHsvColor = HSVColor.fromColor(widget.pickerColor);
+    // If there's no initial text in `hexInputController`,
+    if (widget.hexInputController?.text.isEmpty == true) {
+      // set it to the current's color HEX value.
+      widget.hexInputController?.text = colorToHex(
+        currentHsvColor.toColor(),
+        enableAlpha: widget.enableAlpha,
+      );
+    }
+    // Listen to the text input, If there is an `hexInputController` provided.
+    widget.hexInputController?.addListener(colorPickerTextInputListener);
   }
 
   @override
@@ -55,11 +170,31 @@ class _ColorPickerState extends State<ColorPicker> {
     currentHsvColor = HSVColor.fromColor(widget.pickerColor);
   }
 
+  void colorPickerTextInputListener() {
+    // It can't be null really, since it's only listening if the controller
+    // is provided, but it may help to calm the Dart analyzer in the future.
+    if (widget.hexInputController == null) return;
+    // If a user is inserting/typing any text — try to get the color value from it,
+    final Color? color = colorFromHex(widget.hexInputController!.text,
+        // and interpret its transparency, dependent on the widget's settings.
+        enableAlpha: widget.enableAlpha);
+    // If it's the valid color:
+    if (color != null) {
+      // set it as the current color and
+      setState(() => currentHsvColor = HSVColor.fromColor(color));
+      // notify with a callback.
+      widget.onColorChanged(color);
+    }
+  }
+
   Widget colorPickerSlider(TrackType trackType) {
     return ColorPickerSlider(
       trackType,
       currentHsvColor,
       (HSVColor color) {
+        // Update text in `hexInputController` if provided.
+        widget.hexInputController?.text =
+            colorToHex(color.toColor(), enableAlpha: widget.enableAlpha);
         setState(() => currentHsvColor = color);
         widget.onColorChanged(currentHsvColor.toColor());
       },
@@ -73,6 +208,9 @@ class _ColorPickerState extends State<ColorPicker> {
       child: ColorPickerArea(
         currentHsvColor,
         (HSVColor color) {
+          // Update text in `hexInputController` if provided.
+          widget.hexInputController?.text =
+              colorToHex(color.toColor(), enableAlpha: widget.enableAlpha);
           setState(() => currentHsvColor = color);
           widget.onColorChanged(currentHsvColor.toColor());
         },

--- a/lib/src/hsv_picker.dart
+++ b/lib/src/hsv_picker.dart
@@ -727,7 +727,7 @@ class ColorPickerArea extends StatelessWidget {
 
 class AlwaysWinPanGestureRecognizer extends PanGestureRecognizer {
   @override
-  void addAllowedPointer(PointerDownEvent event) {
+  void addAllowedPointer(event) {
     super.addAllowedPointer(event);
     resolve(GestureDisposition.accepted);
   }

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -52,3 +52,127 @@ HSVColor hslToHsv(HSLColor color) {
     v.clamp(0.0, 1.0),
   );
 }
+
+/// [RegExp] pattern for validation HEX color [String] inputs, allows only:
+///
+/// * exactly 1 to 8 digits in HEX format,
+/// * only Latin A-F characters, case insensitive,
+/// * and integer numbers 0,1,2,3,4,5,6,7,8,9,
+/// * with optional hash (`#`) symbol at the beginning (not calculated in length).
+///
+/// ```dart
+/// final RegExp hexInputValidator = RegExp(kValidHexPattern);
+/// if (hexInputValidator.hasMatch(hex)) print('$hex might be a valid HEX color');
+/// ```
+const String kValidHexPattern = r'^#?[0-9a-fA-F]{1,8}';
+
+/// [RegExp] pattern for validation complete HEX color [String], allows only:
+///
+/// * exactly 6 or 8 digits in HEX format,
+/// * only Latin A-F characters, case insensitive,
+/// * and integer numbers 0,1,2,3,4,5,6,7,8,9,
+/// * with optional hash (`#`) symbol at the beginning (not calculated in length).
+///
+/// ```dart
+/// final RegExp hexCompleteValidator = RegExp(kCompleteValidHexPattern);
+/// if (hexCompleteValidator.hasMatch(hex)) print('$hex is valid HEX color');
+/// ```
+const String kCompleteValidHexPattern = r'^#?([0-9a-fA-F]{6}|[0-9a-fA-F]{8})$';
+
+/// Try to convert text input or any [String] to valid [Color].
+/// The [String] must be provided in one of those formats:
+///
+/// * RRGGBB
+/// * #RRGGBB
+/// * AARRGGBB
+/// * #AARRGGBB
+///
+/// Where: AA stands for Alpha, RR for Red, GG for Green, and BB for blue color.
+/// It will only accept 6/8 long HEXs with an optional hash (`#`) at the beginning.
+/// Allowed characters are Latin A-F case insensitive and numbers 0-9.
+/// Optional [enableAlpha] can be provided (it's `true` by default). If it's set
+/// to `false` transparency information (alpha channel) will be removed.
+/// ```dart
+/// // Valid 6 digit HEXs:
+/// colorFromHex('aabbcc') == Color(0xffaabbcc)
+/// colorFromHex('AABbcc') == Color(0xffaabbcc)
+/// colorFromHex('AABBCC') == Color(0xffaabbcc)
+/// colorFromHex('#AABbcc') == Color(0xffaabbcc)
+/// colorFromHex('#aabbcc') == Color(0xffaabbcc)
+/// colorFromHex('#AABBCC') == Color(0xffaabbcc)
+/// // Valid 8 digit HEXs:
+/// colorFromHex('ffaabbcc') == Color(0xffaabbcc)
+/// colorFromHex('ffAABbcc') == Color(0xffaabbcc)
+/// colorFromHex('ffAABBCC') == Color(0xffaabbcc)
+/// colorFromHex('ffaabbcc', enableAlpha: true) == Color(0xffaabbcc)
+/// colorFromHex('FFAAbbcc', enableAlpha: true) == Color(0xffaabbcc)
+/// colorFromHex('ffAABBCC', enableAlpha: true) == Color(0xffaabbcc)
+/// colorFromHex('FFaabbcc', enableAlpha: true) == Color(0xffaabbcc)
+/// colorFromHex('#ffaabbcc') == Color(0xffaabbcc)
+/// colorFromHex('#ffAABbcc') == Color(0xffaabbcc)
+/// colorFromHex('#FFAABBCC') == Color(0xffaabbcc)
+/// colorFromHex('#ffaabbcc', enableAlpha: true) == Color(0xffaabbcc)
+/// colorFromHex('#FFAAbbcc', enableAlpha: true) == Color(0xffaabbcc)
+/// colorFromHex('#ffAABBCC', enableAlpha: true) == Color(0xffaabbcc)
+/// colorFromHex('#FFaabbcc', enableAlpha: true) == Color(0xffaabbcc)
+/// // Invalid HEXs:
+/// colorFromHex('aabbc') == null // length 5
+/// colorFromHex('#ffaabbccd') == null // length 9 (+#)
+/// colorFromHex('aabbcx') == null // x character
+/// colorFromHex('#aabbвв') == null // в non-latin character
+/// colorFromHex('') == null // empty
+/// ```
+Color? colorFromHex(String inputString, {bool enableAlpha = true}) {
+  // Registers validator for exactly 6 or 8 digits long HEX (with optional #).
+  final RegExp hexValidator = RegExp(kCompleteValidHexPattern);
+  // Validating input, if it does not match — it's not proper HEX.
+  if (!hexValidator.hasMatch(inputString)) return null;
+  // Remove optional hash if exists and convert HEX to UPPER CASE.
+  String hexToParse = inputString.replaceFirst('#', '').toUpperCase();
+  // It may allow HEXs with transparency information even if alpha is disabled,
+  if (!enableAlpha && hexToParse.length == 8) {
+    // but it will replace this info with 100% non-transparent value (FF).
+    hexToParse = 'FF${hexToParse.substring(2)}';
+  }
+  // We will need 8 digits to parse the color, let's add missing digits.
+  if (hexToParse.length == 6) hexToParse = 'FF$hexToParse';
+  // HEX must be valid now, but as a precaution, it will just "try" to parse it.
+  final intColorValue = int.tryParse(hexToParse, radix: 16);
+  // If for some reason HEX is not valid — abort the operation, return nothing.
+  if (intColorValue == null) return null;
+  // Register output color for the last step.
+  final color = Color(intColorValue);
+  // Decide to return color with transparency information or not.
+  return enableAlpha ? color : color.withAlpha(255);
+}
+
+/// Converts `dart:ui` [Color] to the HEX (CSS like) [String].
+/// * exactly 6 or 8 digits in HEX format,
+/// * only Latin A-F characters, case insensitive,
+/// * and integer numbers 0,1,2,3,4,5,6,7,8,9,
+/// * with optional hash (`#`) symbol at the beginning (not calculated in length).
+///
+/// ```dart
+/// final RegExp hexCompleteValidator = RegExp(kCompleteValidHexPattern);
+/// if (hexCompleteValidator.hasMatch(hex)) print('$hex is valid HEX color');
+/// ```
+/// Prefixes a hash sign if [includeHashSign] is set to `true` (default is `false`).
+/// The result will be provided as UPPER CASE, it can be changed via [toUpperCase]
+/// flag set to `false` (default is `true`). Hex can be returned without alpha
+/// channel information (transparency), with the [enableAlpha] flag set to `false`.
+String colorToHex(
+  Color color, {
+  bool includeHashSign = false,
+  bool enableAlpha = true,
+  bool toUpperCase = true,
+}) {
+  final String hex = (includeHashSign ? '#' : '') +
+      (enableAlpha ? _padRadix(color.alpha) : '') +
+      _padRadix(color.red) +
+      _padRadix(color.green) +
+      _padRadix(color.blue);
+  return toUpperCase ? hex.toUpperCase() : hex;
+}
+
+// Shorthand for padLeft of RadixString, DRY.
+String _padRadix(int value) => value.toRadixString(16).padLeft(2, '0');

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_colorpicker
 description: A HSV(HSB)/HSL color picker inspired by chrome devtools and a material color picker for your flutter app.
-version: 0.5.0
+version: 0.6.0
 homepage: https://github.com/mchome/flutter_colorpicker
 
 dependencies:
@@ -10,3 +10,7 @@ dependencies:
 environment:
   sdk: ">=2.12.0 <3.0.0"
   flutter: ">=1.17.0"
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter

--- a/test/src/utils_test.dart
+++ b/test/src/utils_test.dart
@@ -1,0 +1,266 @@
+import 'dart:ui' show Color;
+
+import 'package:flutter_colorpicker/src/utils.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('Test colorFromHex:', () {
+    group('Valid formats test:', () {
+      const Set<String> valid6digits = {'aaBBcc', '#aaBBcc'},
+          valid8digits = {'00aaBBcc', '#00aaBBcc'};
+
+      const expectedColor = Color(0xffaabbcc),
+          expectedColorTransparent = Color(0x00aabbcc);
+      valid6digits.forEach(
+        (format) => test(
+          'It should accept text input with a format: $format, with disabled alpha',
+          () => expect(colorFromHex(format, enableAlpha: false), expectedColor),
+        ),
+      );
+
+      valid6digits.forEach((format) {
+        final upperCaseFormat = format.toUpperCase();
+        test(
+          'It should accept text input with a format: $upperCaseFormat, with disabled alpha',
+          () => expect(
+              colorFromHex(upperCaseFormat, enableAlpha: false), expectedColor),
+        );
+      });
+
+      valid6digits.forEach((format) {
+        final lowerCaseFormat = format.toLowerCase();
+        test(
+          'It should accept text input with a format: $lowerCaseFormat, with disabled alpha',
+          () => expect(
+              colorFromHex(lowerCaseFormat, enableAlpha: false), expectedColor),
+        );
+      });
+
+      valid6digits.forEach(
+        (format) => test(
+          'It should accept text input with a format: $format',
+          () => expect(colorFromHex(format), expectedColor),
+        ),
+      );
+
+      valid6digits.forEach((format) {
+        final upperCaseFormat = format.toUpperCase();
+        test(
+          'It should accept text input with a format: $upperCaseFormat',
+          () => expect(colorFromHex(upperCaseFormat), expectedColor),
+        );
+      });
+
+      valid6digits.forEach((format) {
+        final lowerCaseFormat = format.toLowerCase();
+        test(
+          'It should accept text input with a format: $lowerCaseFormat',
+          () => expect(colorFromHex(lowerCaseFormat), expectedColor),
+        );
+      });
+
+      valid8digits.forEach(
+        (format) => test(
+          'It should accept text input with a format: $format, with disabled alpha',
+          () => expect(colorFromHex(format, enableAlpha: false), expectedColor),
+        ),
+      );
+
+      valid8digits.forEach((format) {
+        final upperCaseFormat = format.toUpperCase();
+        test(
+          'It should accept text input with a format: $upperCaseFormat, with disabled alpha',
+          () => expect(
+              colorFromHex(upperCaseFormat, enableAlpha: false), expectedColor),
+        );
+      });
+
+      valid8digits.forEach((format) {
+        final lowerCaseFormat = format.toLowerCase();
+        test(
+          'It should accept text input with a format: $lowerCaseFormat, with disabled alpha',
+          () => expect(
+              colorFromHex(lowerCaseFormat, enableAlpha: false), expectedColor),
+        );
+      });
+
+      valid8digits.forEach(
+        (format) => test(
+          'It should accept text input with a format: $format',
+          () => expect(colorFromHex(format), expectedColorTransparent),
+        ),
+      );
+
+      valid8digits.forEach((format) {
+        final upperCaseFormat = format.toUpperCase();
+        test(
+          'It should accept text input with a format: $upperCaseFormat',
+          () => expect(colorFromHex(upperCaseFormat), expectedColorTransparent),
+        );
+      });
+
+      valid8digits.forEach((format) {
+        final lowerCaseFormat = format.toLowerCase();
+        test(
+          'It should accept text input with a format: $lowerCaseFormat',
+          () => expect(colorFromHex(lowerCaseFormat), expectedColorTransparent),
+        );
+      });
+    });
+
+    group('Invalid formats test:', () {
+      const Set<String> invalidFormats = {
+        // x char.
+        'aaBBcx',
+        '#aaBBcx',
+        '00aaBBcx',
+        '#00aaBBcx',
+        // á char.
+        'áaBBcc',
+        '#áaBBcc',
+        '00áaBBcc',
+        '#00áaBBcc',
+        // cyrillic а char.
+        'аaBBcc',
+        '#аaBBcc',
+        '00аaBBcc',
+        '#00аaBBcc',
+      };
+      test(
+        'It should return null if text length is not 6 or 8',
+        () {
+          final StringBuffer buffer = StringBuffer();
+          for (int i = 0; i <= 9; i++) {
+            buffer.write(i.toString());
+            expect(colorFromHex(buffer.toString()),
+                (i == 7 || i == 5) ? isNot(null) : null);
+          }
+        },
+      );
+
+      test(
+        'It should return null if text length is not 6 or 8, with alpha disabled',
+        () {
+          final StringBuffer buffer = StringBuffer();
+          for (int i = 0; i <= 9; i++) {
+            buffer.write(i.toString());
+            expect(colorFromHex(buffer.toString(), enableAlpha: false),
+                (i == 7 || i == 5) ? isNot(null) : null);
+          }
+        },
+      );
+
+      invalidFormats.forEach((format) {
+        final lowerCaseFormat = format.toLowerCase();
+        test(
+          'It should return null if format is: $lowerCaseFormat',
+          () => expect(colorFromHex(lowerCaseFormat), null),
+        );
+      });
+
+      invalidFormats.forEach((format) {
+        final upperCaseFormat = format.toUpperCase();
+        test(
+          'It should return null if format is: $upperCaseFormat',
+          () => expect(colorFromHex(upperCaseFormat), null),
+        );
+      });
+
+      invalidFormats.forEach((format) => test(
+            'It should return null if format is: $format',
+            () => expect(colorFromHex(format), null),
+          ));
+
+      invalidFormats.forEach((format) {
+        final lowerCaseFormat = format.toLowerCase();
+        test(
+          'It should return null if format is: $lowerCaseFormat, with alpha disabled',
+          () => expect(colorFromHex(lowerCaseFormat, enableAlpha: false), null),
+        );
+      });
+
+      invalidFormats.forEach((format) {
+        final upperCaseFormat = format.toUpperCase();
+        test(
+          'It should return null if format is: $upperCaseFormat, with alpha disabled',
+          () => expect(colorFromHex(upperCaseFormat, enableAlpha: false), null),
+        );
+      });
+
+      invalidFormats.forEach((format) => test(
+            'It should return null if format is: $format, with alpha disabled',
+            () => expect(colorFromHex(format, enableAlpha: false), null),
+          ));
+    });
+  });
+
+  group('Test colorToHex:', () {
+    final Map<Color, String> colorsMap = {
+      Color(0xffffffff): 'FFFFFF',
+      Color(0x00000000): '000000',
+      Color(0xF0F0F0F0): 'F0F0F0'
+    };
+
+    colorsMap.forEach((color, string) {
+      final String transparency = string.substring(4);
+      test(
+        'It should convert $color: to ${transparency + string}',
+        () => expect(colorToHex(color), transparency + string),
+      );
+    });
+
+    colorsMap.forEach((color, string) {
+      final String transparency = string.substring(4);
+      test(
+        'It should convert $color: to #${transparency + string} with  hash',
+        () => expect(colorToHex(color, includeHashSign: true),
+            '#' + transparency + string),
+      );
+    });
+
+    colorsMap.forEach((color, string) {
+      final String transparency = string.substring(4).toLowerCase();
+      test(
+        'It should convert $color: to #${transparency + string.toLowerCase()}, with hash, to lower case',
+        () => expect(colorToHex(color, includeHashSign: true, toUpperCase: false),
+            '#' + transparency + string.toLowerCase()),
+      );
+    });
+
+    colorsMap.forEach((color, string) {
+      final String transparency = string.substring(4).toLowerCase();
+      test(
+        'It should convert $color to ${transparency + string.toLowerCase()}, with lower case',
+        () => expect(colorToHex(color, toUpperCase: false),
+            transparency + string.toLowerCase()),
+      );
+    });
+
+    //
+    colorsMap.forEach((color, string) => test(
+          'It should convert $color: to $string, with alpha disabled',
+          () => expect(colorToHex(color, enableAlpha: false), string),
+        ));
+
+    colorsMap.forEach((color, string) => test(
+          'It should convert $color: to #$string, with alpha disabled and hash',
+          () => expect(
+              colorToHex(color, enableAlpha: false, includeHashSign: true),
+              '#$string'),
+        ));
+
+    colorsMap.forEach((color, string) => test(
+          'It should convert $color: to #${string.toLowerCase()}, with alpha disabled and hash, to lower case',
+          () => expect(
+              colorToHex(color,
+                  enableAlpha: false, includeHashSign: true, toUpperCase: false),
+              '#$string'.toLowerCase()),
+        ));
+
+    colorsMap.forEach((color, string) => test(
+          'It should convert $color to ${string.toLowerCase()}, with alpha disabled, to lower case',
+          () => expect(colorToHex(color, enableAlpha: false, toUpperCase: false),
+              string.toLowerCase()),
+        ));
+  });
+}


### PR DESCRIPTION
Hey, @mchome it's me again :)

I've added an optional, nullable hexInputController parameter to ColorPicker (which I believe can help you to close Issue #31 ), instead of providing some sort of TextField or changing ColorPickerLabel to editable. So it's not a breaking change.

It allows developers to add their own custom text fields with the ability to create tailor-made validators and formatters for them, from any place of theirs app. It's simply listening to this controller and do basic validation, via two new functions. Almost every line of code is commented on and documented. Also, 122 unit-tests for those two functions were added (since TextEditingController is well tested by Google already :)) and I did not add any widgets. However, I can add some widget tests if you wish to.

I'm open to any critics, and obviously, I'm ok if you don't like this approach, so you are free to close this PR.

Thanks again for your awesome color picker, the best one out there!

Best regards,
Roman