### PR TITLE
Added the support of 3-digit HEXs in manual input.

### DIFF
--- a/lib/src/colorpicker.dart
+++ b/lib/src/colorpicker.dart
@@ -44,13 +44,15 @@ class ColorPicker extends StatefulWidget {
   /// Contains basic validator, that requires final input to be provided
   /// in one of those formats:
   ///
+  /// * RGB
+  /// * #RGB
   /// * RRGGBB
   /// * #RRGGBB
   /// * AARRGGBB
   /// * #AARRGGBB
   ///
-  /// Where: AA stands for Alpha, RR for Red, GG for Green, and BB for blue color.
-  /// It will only accept 6/8 long HEXs with an optional hash (`#`) at the beginning.
+  /// Where: A stands for Alpha, R for Red, G for Green, and B for blue color.
+  /// It will only accept 3/6/8 long HEXs with an optional hash (`#`) at the beginning.
   /// Allowed characters are Latin A-F case insensitive and numbers 0-9.
   /// It does respect the [enableAlpha] flag, so if alpha is disabled, all inputs
   /// with transparency are also converted to non-transparent color values.
@@ -139,6 +141,7 @@ class ColorPicker extends StatefulWidget {
   ///
   /// Do not forget to `dispose()` your [TextEditingController] if you creating
   /// it inside any kind of [StatefulWidget]'s [State].
+  /// Reference: https://en.wikipedia.org/wiki/Web_colors#Hex_triplet
   final TextEditingController? hexInputController;
 
   @override

--- a/test/src/utils_test.dart
+++ b/test/src/utils_test.dart
@@ -6,11 +6,12 @@ import 'package:flutter_test/flutter_test.dart';
 void main() {
   group('Test colorFromHex:', () {
     group('Valid formats test:', () {
-      const Set<String> valid6digits = {'aaBBcc', '#aaBBcc'},
+      const Set<String> valid6digits = {'aBc', '#aBc', 'aaBBcc', '#aaBBcc'},
           valid8digits = {'00aaBBcc', '#00aaBBcc'};
 
-      const expectedColor = Color(0xffaabbcc),
+      const Color expectedColor = Color(0xffaabbcc),
           expectedColorTransparent = Color(0x00aabbcc);
+
       valid6digits.forEach(
         (format) => test(
           'It should accept text input with a format: $format, with disabled alpha',
@@ -127,25 +128,25 @@ void main() {
         '#00аaBBcc',
       };
       test(
-        'It should return null if text length is not 6 or 8',
+        'It should return null if text length is not 3, 6 or 8',
         () {
           final StringBuffer buffer = StringBuffer();
           for (int i = 0; i <= 9; i++) {
             buffer.write(i.toString());
             expect(colorFromHex(buffer.toString()),
-                (i == 7 || i == 5) ? isNot(null) : null);
+                (i == 7 || i == 5 || i == 2) ? isNot(null) : null);
           }
         },
       );
 
       test(
-        'It should return null if text length is not 6 or 8, with alpha disabled',
+        'It should return null if text length is not 3, 6 or 8, with alpha disabled',
         () {
           final StringBuffer buffer = StringBuffer();
           for (int i = 0; i <= 9; i++) {
             buffer.write(i.toString());
             expect(colorFromHex(buffer.toString(), enableAlpha: false),
-                (i == 7 || i == 5) ? isNot(null) : null);
+                (i == 7 || i == 5 || i == 2) ? isNot(null) : null);
           }
         },
       );
@@ -212,7 +213,7 @@ void main() {
     colorsMap.forEach((color, string) {
       final String transparency = string.substring(4);
       test(
-        'It should convert $color: to #${transparency + string} with  hash',
+        'It should convert $color: to #${transparency + string} with hash',
         () => expect(colorToHex(color, includeHashSign: true),
             '#' + transparency + string),
       );
@@ -236,7 +237,6 @@ void main() {
       );
     });
 
-    //
     colorsMap.forEach((color, string) => test(
           'It should convert $color: to $string, with alpha disabled',
           () => expect(colorToHex(color, enableAlpha: false), string),


### PR DESCRIPTION
Hey, @mchome it's me again 😄 

Thanks for merging my PR with manual input a few days ago! In this PR you will find the last (hopefully :)) part for manual HEX colors inputs validation: so-called "[Shorthand hexadecimal form](https://en.wikipedia.org/wiki/Web_colors#Shorthand_hexadecimal_form)". So it now supports all standard forms for hex triplets. I have slightly corrected previous descriptions, added new tests for the new format and Wikipedia reference. Feel free to let me know whatever you think. Thanks for your package again!