### PR TITLE
Enable ColorPickerInput in landscape mode

### DIFF
--- a/lib/src/colorpicker.dart
+++ b/lib/src/colorpicker.dart
@@ -432,7 +432,6 @@ class _ColorPickerState extends State<ColorPicker> {
                   },
                   enableAlpha: widget.enableAlpha,
                   embeddedText: false,
-                  disable: true,
                 ),
               const SizedBox(height: 5),
             ],


### PR DESCRIPTION
When ColorPicker was used in landscape mode with ColorPickerInput enabled (hexInputBar == true), ColorPickerInput was disabled. Removed disabled attribute.