### PR TITLE
Implemented option to remove color indicator and to change the width of the pallete type slider

### DIFF
--- a/lib/src/colorpicker.dart
+++ b/lib/src/colorpicker.dart
@@ -22,6 +22,7 @@ class ColorPicker extends StatefulWidget {
     this.labelTypes = const [ColorLabelType.rgb, ColorLabelType.hsv, ColorLabelType.hsl],
     @Deprecated('Use Theme.of(context).textTheme.bodyText1 & 2 to alter text style.') this.labelTextStyle,
     this.displayThumbColor = false,
+    this.displayColorIndicator = true,
     this.portraitOnly = false,
     this.colorPickerWidth = 300.0,
     this.pickerAreaHeightPercent = 1.0,
@@ -47,6 +48,7 @@ class ColorPicker extends StatefulWidget {
   final double pickerAreaHeightPercent;
   final BorderRadius pickerAreaBorderRadius;
   final bool hexInputBar;
+  final bool displayColorIndicator;
 
   /// Allows setting the color using text input, via [TextEditingController].
   ///
@@ -290,13 +292,17 @@ class _ColorPickerState extends State<ColorPicker> {
               mainAxisAlignment: MainAxisAlignment.center,
               children: <Widget>[
                 GestureDetector(
-                  onTap: () => setState(() {
-                    if (widget.onHistoryChanged != null && !colorHistory.contains(currentHsvColor.toColor())) {
-                      colorHistory.add(currentHsvColor.toColor());
-                      widget.onHistoryChanged!(colorHistory);
+                  onTap: () {
+                    if (widget.displayColorIndicator) {
+                      setState(() {
+                        if (widget.onHistoryChanged != null && !colorHistory.contains(currentHsvColor.toColor())) {
+                          colorHistory.add(currentHsvColor.toColor());
+                          widget.onHistoryChanged!(colorHistory);
+                        }
+                      });
                     }
-                  }),
-                  child: ColorIndicator(currentHsvColor),
+                  },
+                  child: widget.displayColorIndicator ? ColorIndicator(currentHsvColor) : const SizedBox(),
                 ),
                 Expanded(
                   child: Column(

--- a/lib/src/colorpicker.dart
+++ b/lib/src/colorpicker.dart
@@ -23,6 +23,7 @@ class ColorPicker extends StatefulWidget {
     @Deprecated('Use Theme.of(context).textTheme.bodyText1 & 2 to alter text style.') this.labelTextStyle,
     this.displayThumbColor = false,
     this.displayColorIndicator = true,
+    this.palletTypeSliderWidth = 225.0,
     this.portraitOnly = false,
     this.colorPickerWidth = 300.0,
     this.pickerAreaHeightPercent = 1.0,
@@ -49,6 +50,7 @@ class ColorPicker extends StatefulWidget {
   final BorderRadius pickerAreaBorderRadius;
   final bool hexInputBar;
   final bool displayColorIndicator;
+  final double palletTypeSliderWidth;
 
   /// Allows setting the color using text input, via [TextEditingController].
   ///
@@ -307,7 +309,13 @@ class _ColorPickerState extends State<ColorPicker> {
                 Expanded(
                   child: Column(
                     children: <Widget>[
-                      SizedBox(height: 40.0, width: widget.colorPickerWidth - 75.0, child: sliderByPaletteType()),
+                      SizedBox(
+                        height: 40.0,
+                        width: widget.displayColorIndicator
+                            ? widget.palletTypeSliderWidth
+                            : widget.colorPickerWidth - 75.0,
+                        child: sliderByPaletteType(),
+                      ),
                       if (widget.enableAlpha)
                         SizedBox(
                           height: 40.0,

--- a/lib/src/colorpicker.dart
+++ b/lib/src/colorpicker.dart
@@ -312,8 +312,8 @@ class _ColorPickerState extends State<ColorPicker> {
                       SizedBox(
                         height: 40.0,
                         width: widget.displayColorIndicator
-                            ? widget.palletTypeSliderWidth
-                            : widget.colorPickerWidth - 75.0,
+                            ? widget.colorPickerWidth - 75.0
+                            : widget.palletTypeSliderWidth,
                         child: sliderByPaletteType(),
                       ),
                       if (widget.enableAlpha)


### PR DESCRIPTION
Now the developers can remove the color indicator by setting `displayColorIndicator` to false. the default value is `true`. And also to fill the excess space they can change the width of the PalletType slider. You can change this by setting `palletTypeSliderWidth`. default value is `225` which comes from default `colorPickerWidth - 75.00`. This option is only available when the `displayColorIndicator` is set to false.