### PR TITLE
Fix: Material colorpicker label gets string by converting color value to hexadecimal instead of using toString method

### DIFF
--- a/lib/src/material_picker.dart
+++ b/lib/src/material_picker.dart
@@ -232,7 +232,7 @@ class _MaterialPickerState extends State<MaterialPicker> {
                             child: Align(
                               alignment: Alignment.centerRight,
                               child: Text(
-                                '#${(_color.toString().replaceFirst('Color(0xff', '').replaceFirst(')', '')).toUpperCase()}  ',
+                                '#${(_color.value.toRadixString(16).padLeft(8, '0')).substring(2).toUpperCase()}  ',
                                 style: TextStyle(
                                   color: useWhiteForeground(_color) ? Colors.white : Colors.black,
                                   fontWeight: FontWeight.bold,


### PR DESCRIPTION
Fix for #119 

Using `toString` method on Type `Color` will only work in debug mode. On profile or release mode, the `toString()` method returns an Instance of 'Color'. The solution to this is to convert the value of Type `Color` to hexadecimal with `toRadixString(16)` method.

The `subString(2)` is used to remove the first to "ff" like was done before with the `replaceFirst()` method.