### PR TITLE
Disable setting blendMode, to avoid broken horizontal and vertical lines

### DIFF
--- a/lib/src/palette.dart
+++ b/lib/src/palette.dart
@@ -79,7 +79,8 @@ class HSVWithHueColorPainter extends CustomPainter {
       Paint()
         ..color = pointerColor ?? (useWhiteForeground(hsvColor.toColor()) ? Colors.white : Colors.black)
         ..strokeWidth = 1.5
-        ..blendMode = BlendMode.luminosity
+        // https://github.com/mchome/flutter_colorpicker/issues/130
+        // ..blendMode = BlendMode.luminosity
         ..style = PaintingStyle.stroke,
     );
   }


### PR DESCRIPTION
Note: I don't know the implication of changing the blendMode here, or why it needed to be set in the first place, but this change does happen to fix https://github.com/mchome/flutter_colorpicker/issues/130.